### PR TITLE
feat: update redirect after signup and enhance user data display in p…

### DIFF
--- a/frontend/src/routes/auth/+page.server.ts
+++ b/frontend/src/routes/auth/+page.server.ts
@@ -29,7 +29,7 @@ export const actions: Actions = {
       console.error(error);
       redirect(303, "/auth/error");
     } else {
-      redirect(303, "/private");
+      redirect(303, "/");
     }
   },
 };

--- a/frontend/src/routes/private/+layout.svelte
+++ b/frontend/src/routes/private/+layout.svelte
@@ -1,27 +1,30 @@
 <script>
-  import { goto } from "$app/navigation";
-  import { Button } from "$lib/components/ui/button/index.js";
-  import { Card } from "$lib/components/ui/card/index.js";
+  // TODO: Remove these imports after moving buttons to page
+  // import { goto } from "$app/navigation";
+  // import { Button } from "$lib/components/ui/button/index.js";
+  // import { Card } from "$lib/components/ui/card/index.js";
 
   let { data, children } = $props();
-  let { supabase } = $derived(data);
+  // let { supabase } = $derived(data);
 
-  const logout = async () => {
-    const { error } = await supabase.auth.signOut();
-    if (error) {
-      console.error(error);
-    } else {
-      goto("/auth");
-    }
-  };
+  // TODO: Remove this logout function after moving to page
+  // const logout = async () => {
+  //   const { error } = await supabase.auth.signOut();
+  //   if (error) {
+  //     console.error(error);
+  //   } else {
+  //     goto("/auth");
+  //   }
+  // };
 </script>
 
-<header>
+<!-- TODO: Remove this header after moving buttons to page -->
+<!-- <header>
   <Button>
     <a href="/">Home</a>
   </Button>
   <Button class="cursor-pointer" onclick={logout}>Logout</Button>
-</header>
+</header> -->
 <main>
   {@render children()}
 </main>

--- a/frontend/src/routes/private/+page.server.ts
+++ b/frontend/src/routes/private/+page.server.ts
@@ -1,21 +1,32 @@
 import type { PageServerLoad } from "./$types";
+import { supabase } from "$lib/supabaseClient";
 
-export const load: PageServerLoad = async ({
-  depends,
-  locals: { supabase },
-  parent,
-}) => {
-  // Get user/session data from parent layout
+// READ - Load current user data without authentication check
+export const load: PageServerLoad = async ({ parent }) => {
+  // Get parent data (includes session, user, userProfile)
   const parentData = await parent();
 
-  depends("supabase:db:notes");
-  const { data: notes } = await supabase
-    .from("notes")
-    .select("id,note")
-    .order("id");
+  // Fetch current user from the database using the direct supabase client
+  const { data, error } = await supabase
+    .from("user")
+    .select()
+    .eq("id", parentData.user?.id);
+
+  // Handle errors gracefully
+  if (error) {
+    console.error("Supabase error:", error);
+    return {
+      ...parentData,
+      currentUser: null,
+      error: error.message,
+    };
+  }
+
+  console.log("✅ Current user data from database:", data);
+  console.log("✅ Extracting first user from array:", data ? data[0] : null);
 
   return {
-    ...parentData, // This includes session, user, userProfile from root layout
-    notes: notes ?? [],
+    ...parentData,
+    currentUser: data ? data[0] : null,
   };
 };

--- a/frontend/src/routes/private/+page.svelte
+++ b/frontend/src/routes/private/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invalidate } from "$app/navigation";
+  import { invalidate, goto } from "$app/navigation";
   import type { EventHandler } from "svelte/elements";
   import * as Card from "$lib/components/ui/card/index.js";
   import type { PageData } from "./$types";
@@ -10,11 +10,41 @@
   import SunMoon from "@lucide/svelte/icons/sun-moon";
 
   let { data } = $props();
-  let { supabase, user } = $derived(data);
+  let { supabase, user, currentUser } = $derived(data);
+
+  const logout = async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      console.error(error);
+    } else {
+      goto("/auth");
+    }
+  };
+
+  type User = {
+    id: string;
+    email: string;
+    firstName: string | null;
+    lastName: string | null;
+    phone: string | null;
+    dateOfBirth: string | null;
+    addressLine: string | null;
+    city: string | null;
+    state: string | null;
+    postalCode: string | null;
+    rfidTag: string | null;
+    volunteerStartDate: string | null;
+    volunteerEndDate: string | null;
+    volunteerNotes: string | null;
+    isAdmin: boolean;
+    isActiveVolunteer: boolean;
+    createdAt: string | null;
+    updatedAt: string | null;
+  };
 </script>
 
-<div class="p-6 pb-0">
-  <div class="flex items-center justify-between">
+<div class="p-6">
+  <div class="flex items-center justify-between mb-6">
     <div class="space-y-1">
       <h1
         class="scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl"
@@ -26,22 +56,139 @@
       </p>
     </div>
   </div>
+
+  <header class="flex gap-4 mb-6">
+    <Button>
+      <a href="/">Dashboard</a>
+    </Button>
+    <Button class="cursor-pointer" onclick={logout}>Logout</Button>
+    <Button onclick={toggleMode}><SunMoon /> Toggle mode</Button>
+  </header>
+
+  <Card.Root class="w-full max-w-sm">
+    <Card.Header>
+      <Card.Title>Current User</Card.Title>
+      <Card.Description>{currentUser?.email}</Card.Description>
+    </Card.Header>
+    <Card.Content>
+      {#if currentUser}
+        <div class="space-y-4">
+          <!-- Name -->
+          <div>
+            <Card.Title>Name</Card.Title>
+            <Card.Description>
+              {currentUser.first_name || ""}
+              {currentUser.last_name || ""}
+            </Card.Description>
+          </div>
+
+          <!-- Phone -->
+          <div>
+            <Card.Title>Phone</Card.Title>
+            <Card.Description
+              >{currentUser.phone || "Not provided"}</Card.Description
+            >
+          </div>
+
+          <!-- Date of Birth -->
+          <div>
+            <Card.Title>Date of Birth</Card.Title>
+            <Card.Description
+              >{currentUser.date_of_birth || "Not provided"}</Card.Description
+            >
+          </div>
+
+          <!-- Address -->
+          <div>
+            <Card.Title>Address</Card.Title>
+            <Card.Description
+              >{currentUser.address_line || "Not provided"}</Card.Description
+            >
+          </div>
+
+          <!-- City -->
+          <div>
+            <Card.Title>City</Card.Title>
+            <Card.Description
+              >{currentUser.city || "Not provided"}</Card.Description
+            >
+          </div>
+
+          <!-- State -->
+          <div>
+            <Card.Title>State</Card.Title>
+            <Card.Description
+              >{currentUser.state || "Not provided"}</Card.Description
+            >
+          </div>
+
+          <!-- Postal Code -->
+          <div>
+            <Card.Title>Postal Code</Card.Title>
+            <Card.Description
+              >{currentUser.postal_code || "Not provided"}</Card.Description
+            >
+          </div>
+
+          <!-- Status -->
+          {#if currentUser.is_active_volunteer}
+            <div>
+              <Card.Title>Status</Card.Title>
+              <Card.Description>Active Volunteer</Card.Description>
+            </div>
+          {/if}
+
+          <!-- Volunteer Since -->
+          {#if currentUser.is_active_volunteer}
+            <div>
+              <Card.Title>Volunteer Since</Card.Title>
+              <Card.Description
+                >{currentUser.volunteer_start_date ||
+                  "Not provided"}</Card.Description
+              >
+            </div>
+          {/if}
+
+          <!-- Role -->
+          {#if currentUser.is_admin}
+            <div>
+              <Card.Title>Role</Card.Title>
+              <Card.Description>Administrator</Card.Description>
+            </div>
+          {/if}
+
+          <!-- RFID Tag -->
+          {#if currentUser.rfid_tag}
+            <div>
+              <Card.Title>RFID Tag</Card.Title>
+              <Card.Description>{currentUser.rfid_tag}</Card.Description>
+            </div>
+          {/if}
+
+          <!-- Volunteer Notes -->
+          {#if currentUser.volunteer_notes}
+            <div>
+              <Card.Title>Volunteer Notes</Card.Title>
+              <Card.Description>{currentUser.volunteer_notes}</Card.Description>
+            </div>
+          {/if}
+
+          <!-- Member Since -->
+          <div>
+            <Card.Title>Member Since</Card.Title>
+            <Card.Description>
+              {#if currentUser.created_at}
+                {new Date(currentUser.created_at).toLocaleDateString()}
+              {:else}
+                Not available
+              {/if}
+            </Card.Description>
+          </div>
+        </div>
+      {:else}
+        <Card.Title>Loading</Card.Title>
+        <Card.Description>Loading user data...</Card.Description>
+      {/if}
+    </Card.Content>
+  </Card.Root>
 </div>
-
-<Card.Root class="w-full max-w-sm">
-  <Card.Header>
-    <Card.Title>Current User</Card.Title>
-    <Card.Description>{user?.email}</Card.Description>
-  </Card.Header>
-</Card.Root>
-
-<!-- Light Dark Toggle -->
-<!-- <Button
-  class="border border-sidebar-primary/20 cursor-pointer"
-  onclick={toggleMode}
->
-  <SunMoon />
-  <span>Toggle Theme</span>
-</Button> -->
-
-<Button onclick={toggleMode}><SunMoon /> Toggle mode</Button>

--- a/frontend/src/routes/scan-logs/+page.svelte
+++ b/frontend/src/routes/scan-logs/+page.svelte
@@ -17,7 +17,7 @@
         Scan Logs
       </h1>
       <p class="text-xl text-muted-foreground">
-        View all recent scan logs for your animals.
+        View all recent scan logs for your animals
       </p>
     </div>
   </div>


### PR DESCRIPTION
This pull request refactors the user authentication and profile display logic in the private user dashboard. The main changes include moving logout and header UI elements from the layout to the page, updating the redirect after authentication, and enhancing the user profile card to display comprehensive user information fetched directly from the database.

**Authentication and Routing Updates**
* The post-authentication redirect now sends users to the home page (`/`) instead of the private dashboard (`/private`).
* The logout logic and header UI (buttons) have been moved from the `+layout.svelte` file to the `+page.svelte` file, with the old code commented out and marked for removal. [[1]](diffhunk://#diff-0b271ae79f5191dd3810e9ba6f4a51218709d60e05e797db512f6daa35d3c610L2-R27) [[2]](diffhunk://#diff-cf1f2041c01e8091cf1705c525370b293f2080c526f134af08eb3dcf4f33918aL13-R47) [[3]](diffhunk://#diff-cf1f2041c01e8091cf1705c525370b293f2080c526f134af08eb3dcf4f33918aL29-R194)

**User Data Loading and Display**
* The `+page.server.ts` now loads the current user's full profile directly from the database using the Supabase client, and passes it to the page as `currentUser`. Error handling is improved for database fetch failures.
* The user profile card in `+page.svelte` is expanded to show detailed fields such as name, contact info, address, volunteer status, admin role, RFID tag, notes, and membership dates, all sourced from `currentUser`.

**Minor UI/UX Improvements**
* The scan logs page description is slightly updated for clarity.…rivate routes